### PR TITLE
patch Line 74

### DIFF
--- a/spenden.html
+++ b/spenden.html
@@ -71,7 +71,7 @@
         
         </p>
         <p>
-          Der Verein ist nicht als gemeinnützig anerkannt, daher kann er keine Steuerlich absetzbare Spendenbescheinigung ausstellen, aber eine normale Spendenbescheinigung. Der Vorteil ist, dass dadurch Spenden unkomplizierter und flexibler eingesetzt werden können und ohne großen Verwaltungsaufwand schnell dem Freifunk-Ausbau zugute kommen können.
+          Der Verein ist nicht als gemeinnützig anerkannt, er kann Spendenbescheinigung ausstellen, die aber nicht steuerlich absetzbar sind. Der Vorteil ist, dass dadurch Spenden unkomplizierter und flexibler eingesetzt werden können und ohne großen Verwaltungsaufwand schnell dem Freifunk-Ausbau zugute kommen können.
         </p>
       
       </div>


### PR DESCRIPTION
- 74 Der Verein ist nicht als gemeinnützig anerkannt, daher kann er keine Steuerlich absetzbare Spendenbescheinigung ausstellen, aber eine normale Spendenbescheinigung.
- Der Verein ist nicht als gemeinnützig anerkannt, er kann Spendenbescheinigung ausstellen, die aber nicht steuerlich absetzbar sind.
